### PR TITLE
(#30, #32) Bump NSwag.AspNetCore to v13.20

### DIFF
--- a/src/NCI.OCPL.Api.ResourcesForResearchers/Controllers/ResourceController.cs
+++ b/src/NCI.OCPL.Api.ResourcesForResearchers/Controllers/ResourceController.cs
@@ -52,8 +52,8 @@ namespace NCI.OCPL.Api.ResourcesForResearchers.Controllers
 
             if(result == null)
             {
-                _logger.LogError("Could not fetch resource for ID " + id);
-                throw new APIErrorException(404, "Could not fetch resource for ID " + id);
+                _logger.LogError($"Could not fetch resource for ID {id}");
+                throw new APIErrorException(404, $"Could not fetch resource for ID {id}");
             }
 
             return result;

--- a/src/NCI.OCPL.Api.ResourcesForResearchers/NCI.OCPL.Api.ResourcesForResearchers.csproj
+++ b/src/NCI.OCPL.Api.ResourcesForResearchers/NCI.OCPL.Api.ResourcesForResearchers.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Elasticsearch.Net" Version="7.9.*" />
     <PackageReference Include="NCI.OCPL.Api.Common" Version="2.0.*" />
-    <PackageReference Include="NSwag.AspNetCore" Version="13.11.*" />
+    <PackageReference Include="NSwag.AspNetCore" Version="13.20.*" />
     <PackageReference Include="NEST" Version="7.9.*" />
   </ItemGroup>
 

--- a/src/NCI.OCPL.Api.ResourcesForResearchers/Services/ESResourceQueryService.cs
+++ b/src/NCI.OCPL.Api.ResourcesForResearchers/Services/ESResourceQueryService.cs
@@ -59,7 +59,7 @@ namespace NCI.OCPL.Api.ResourcesForResearchers.Services
                 catch (Exception ex)
                 {
                     // Throw an exception if an error occurs.
-                    _logger.LogError("Could not fetch resource ID " + resID, ex);
+                    _logger.LogError(ex, $"Could not fetch resource ID {resID}");
                     throw new APIErrorException(500, "Could not fetch resource ID " + resID);
                 }
 
@@ -140,7 +140,7 @@ namespace NCI.OCPL.Api.ResourcesForResearchers.Services
             catch (Exception ex)
             {
                 //TODO: Update error logger to include query
-                _logger.LogError("Could not fetch resources for query.", ex);
+                _logger.LogError(ex, "Could not fetch resources for query.");
                 throw new APIErrorException(500, "Could not fetch resources for query.");
             }
 


### PR DESCRIPTION
Closes #30
Closes #32 

Testing needs:
- Standard regression tests
- Verify navigating to https://webapis-dev.cancer.gov/r4r/v1/index.html?configUrl=https://jumpy-floor.surge.sh/test.json displays the R4R Swagger page.