### PR TITLE
(#36) Use Elasticsearch in v7.17.28 integration tests. 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   ci_remote:
-    uses: nciocpl/nci.ocpl.api.shared/.github/workflows/common-api-ci.yml@v2.x
+    uses: nciocpl/nci.ocpl.api.shared/.github/workflows/common-api-ci.yml@workflow/v1
     with:
       api-project: src/NCI.OCPL.Api.ResourcesForResearchers/NCI.OCPL.Api.ResourcesForResearchers.csproj
       artifact-name: r4r

--- a/integration-tests/docker-r4r-api/api/Dockerfile
+++ b/integration-tests/docker-r4r-api/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
 WORKDIR /app
 
 # Get the NIH Root certificates and install them so we work on VPN

--- a/integration-tests/docker-r4r-api/docker-compose.yml
+++ b/integration-tests/docker-r4r-api/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
     elasticsearch:
         build:

--- a/integration-tests/docker-r4r-api/elasticsearch/Dockerfile
+++ b/integration-tests/docker-r4r-api/elasticsearch/Dockerfile
@@ -1,4 +1,4 @@
-FROM elasticsearch:7.17.5
+FROM elasticsearch:7.17.28
 
 # Get the NIH Root certificates and install them so we work on VPN
 # Download from https://ocio.nih.gov/Smartcard/Pages/PKI_chain.aspx


### PR DESCRIPTION
- Access shared workflow as workflow/v1.
- Fix lingering problem with wrong .Net version in API test Dockerfile.
- Remove obsolete version property from Docker compose file.

Closes https://github.com/NCIOCPL/r4r-api/issues/36